### PR TITLE
Fix on linux

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.15...3.29)
 
 # There are some incompatibilities with Swift and gcc
 # Therefore we have to specify explicitly to use clang
-set(CMAKE_C_COMPILER "clang")
-set(CMAKE_CXX_COMPILER "clang")
+# set(CMAKE_C_COMPILER "clang")
+# set(CMAKE_CXX_COMPILER "clang")
 
 ##########
 # Python #
@@ -14,7 +14,9 @@ project(
   VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
-set(PYBIND11_FINDPYTHON ON)
+# Find the module development requirements (requires FindPython from 3.17 or
+# scikit-build-core's built-in backport)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
 #########
@@ -23,7 +25,7 @@ find_package(pybind11 CONFIG REQUIRED)
 # Add a custom target to build the Swift project, this will always be built!
 add_custom_command(
     OUTPUT ${CMAKE_SOURCE_DIR}/../Swift/.build/debug/libOmFileInterface.a
-    COMMAND swift build
+    COMMAND echo "Skipping Swift build"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../Swift
     COMMENT "Building Swift static library"
     VERBATIM
@@ -37,12 +39,16 @@ add_custom_target(BuildSwiftOmFiles ALL
 add_library(OmFilesLib STATIC IMPORTED)
 add_dependencies(OmFilesLib BuildSwiftOmFiles)
 # IMPORTED_LOCATION needs to be an absolute path
-set_target_properties(OmFilesLib PROPERTIES IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/../Swift/.build/debug/libOmFileInterface.a)
+set_target_properties(
+  OmFilesLib
+  PROPERTIES
+  IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/../Swift/.build/debug/libOmFileInterface.a
+)
 
 # Add a library using FindPython's tooling (pybind11 also provides a helper like this)
 python_add_library(bindings MODULE bindings.cpp WITH_SOABI)
 add_dependencies(bindings OmFilesLib)
-target_link_libraries(bindings PRIVATE OmFilesLib)
 target_link_libraries(bindings PRIVATE pybind11::headers)
+target_link_libraries(bindings PRIVATE OmFilesLib)
 
 install(TARGETS bindings DESTINATION omfilespy)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,50 +1,52 @@
-// #include <pybind11/numpy.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 // C++ wrapper for the Swift function
-extern "C" {
-float om_hello_from_swift();  // Declaration of the Swift function
+extern "C"
+{
+  float om_hello_from_swift(); // Declaration of the Swift function
 
-void om_read_float_array(const char* file, float* into, int dim0Start,
-                         int dim0End, int dim1Start, int dim1End);
+  // void om_read_float_array(const char* file, float* into, int dim0Start,
+  //                          int dim0End, int dim1Start, int dim1End);
 }
 
-py::array_t<float> readOmFile(const std::string& file, int dim0Start,
-                              int dim0End, int dim1Start, int dim1End) {
-  int buffer_size = (dim0End - dim0Start) * (dim1End - dim1Start);
-  // create a new buffer pointer where we can write the output from swift
-  float* buffer = new float[buffer_size];
+// py::array_t<float> readOmFile(const std::string &file, int dim0Start,
+//                               int dim0End, int dim1Start, int dim1End)
+// {
+//   int buffer_size = (dim0End - dim0Start) * (dim1End - dim1Start);
+//   // create a new buffer pointer where we can write the output from swift
+//   float *buffer = new float[buffer_size];
 
-  // Call the extern C function and get the array of floats
-  om_read_float_array(file.c_str(), buffer, dim0Start, dim0End, dim1Start,
-                      dim1End);
-  // convert the buffer to a pybind array to return it
-  // Create a pybind11 buffer_info object to describe the buffer
-  py::buffer_info buf_info(
-      buffer,                                 /* Pointer to buffer */
-      sizeof(float),                          /* Size of one scalar */
-      py::format_descriptor<float>::format(), /* Python struct-style format
-                                                 descriptor */
-      1,                                      /* Number of dimensions */
-      {buffer_size},                          /* Buffer dimensions */
-      {sizeof(float)}                         /* Strides (in bytes)
-                                                 for each index */
-  );
+//   // Call the extern C function and get the array of floats
+//   om_read_float_array(file.c_str(), buffer, dim0Start, dim0End, dim1Start,
+//                       dim1End);
+//   // convert the buffer to a pybind array to return it
+//   // Create a pybind11 buffer_info object to describe the buffer
+//   py::buffer_info buf_info(
+//       buffer,                                 /* Pointer to buffer */
+//       sizeof(float),                          /* Size of one scalar */
+//       py::format_descriptor<float>::format(), /* Python struct-style format
+//                                                  descriptor */
+//       1,                                      /* Number of dimensions */
+//       {buffer_size},                          /* Buffer dimensions */
+//       {sizeof(float)}                         /* Strides (in bytes)
+//                                                  for each index */
+//   );
 
-  // Create a pybind11 array from the buffer_info
-  py::array_t<float> result(buf_info);
+//   // Create a pybind11 array from the buffer_info
+//   py::array_t<float> result(buf_info);
 
-  // Don't forget to free the memory!
-  delete[] buffer;
+//   // Don't forget to free the memory!
+//   delete[] buffer;
 
-  return result;
-};
+//   return result;
+// };
 
-PYBIND11_MODULE(bindings, m) {
-  m.doc() = "pybind11 om-files swift bindings";  // optional module docstring
+PYBIND11_MODULE(bindings, m)
+{
+  m.doc() = "pybind11 om-files swift bindings"; // optional module docstring
 
   m.def("om_hello_from_swift", &om_hello_from_swift,
         "A function that does not add two numbers");
@@ -52,5 +54,5 @@ PYBIND11_MODULE(bindings, m) {
   // m.def("om_read_float_array", &om_read_float_array,
   // "Read Float array from an om file");
 
-  m.def("readOmFile", &readOmFile, "Read Float array from an om file");
+  // m.def("readOmFile", &readOmFile, "Read Float array from an om file");
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 build.verbose = true
+logging.level = "DEBUG"
 wheel.expand-macos-universal-tags = true
 
 [tool.pyright]

--- a/python/tests/test_omfiles_bindings.py
+++ b/python/tests/test_omfiles_bindings.py
@@ -1,5 +1,6 @@
-import omfilespy as om
 import numpy.testing as npt
+
+import omfilespy as om
 
 
 def test_om_hello_from_swift():


### PR DESCRIPTION
Some Swift symbols can not be found on runtime when building on Linux. On Mac everything is fine.